### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run start"

--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ Command | Description
 ## See also
 * [React Webpack Babel Starter](https://github.com/vikpe/react-webpack-babel-starter)
 * [Isomorphic Webapp Starter](https://github.com/vikpe/isomorphic-webapp-starter)
+
+[![Run on Repl.it](https://repl.it/badge/github/Neuraxis/react-template)](https://repl.it/github/Neuraxis/react-template)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Neuraxis/react-template).